### PR TITLE
add support for --set-cookie option (solves issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ sitemaps:                                             # (required/optional) Site
   - url: 'https://ovhcloud.com/fr/sitemap.xml'
     exclude: '/^exclude/these/url$/'
   - file: '/path/to/sitemap_custom.xml'
+setCookie: cookies.txt                                # (optional) --set-cookie option to be passed to website-evidence-collector
+                                                      # see https://github.com/EU-EDPS/website-evidence-collector/blob/master/FAQ.md#how-do-i-gather-evidence-with-given-consent 
 ```
 
 You must provide at least one item in `urls` and/or `sitemaps`.

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ const validateConfig = async (config) => {
     workers: Joi.number().integer(),
     dnt: Joi.boolean(),
     firstPartyUri: Joi.string().uri().required(),
+    setCookie: Joi.string(),
     urls: Joi.array().items(Joi.string().uri().required()),
     sitemaps: Joi.array().items(Joi.object().keys({
       url: Joi.string().uri(),
@@ -352,7 +353,7 @@ const setupWorker = async (config) => {
     };
 
     try {
-      const command = `website-evidence-collector ${url} --first-party-uri="${config.get('firstPartyUri')}" ${config.get('dnt') ? '--dnt-js' : ''} --sleep=3000 --overwrite --quiet --no-output --json --headless -- --disable-gpu --ignore-certificate-errors --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage`;
+      const command = `website-evidence-collector ${url} --first-party-uri="${config.get('firstPartyUri')}" ${config.get('dnt') ? '--dnt-js' : ''} ${config.get('setCookie') ? '--set-cookie "'+config.get('setCookie')+'"' : ''} --sleep=3000 --overwrite --quiet --no-output --json --headless -- --disable-gpu --ignore-certificate-errors --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage`;
       const { stdout } = await execa.command(command, { timeout: 30000 });
       result.results = JSON.parse(stdout);
 


### PR DESCRIPTION
The latest master branch version of website-evidence-collector allows to pre-install a consent cookie through the --set-cookie option, so that the parsed website receives it and assumes from the beginning of the browsing session that consent to cookies has been obtained.

website-evidence-collector-batch should definitely support this option, since it is fundamental to collect evidence on which cookies are actually installed when user agrees to cookies.